### PR TITLE
[OWL-456] Modified the JSONRPC2 library from powerman

### DIFF
--- a/jsonrpc2/http.go
+++ b/jsonrpc2/http.go
@@ -100,8 +100,6 @@ func (conn *httpClientConn) Write(buf []byte) (int, error) {
 			var resp *http.Response
 			resp, err = (&http.Client{}).Do(req)
 			if err != nil {
-			} else if resp.Header.Get("Content-Type") != contentType {
-				err = fmt.Errorf("bad HTTP Content-Type: %s", resp.Header.Get("Content-Type"))
 			} else if resp.StatusCode == http.StatusOK {
 				conn.ready <- resp.Body
 				return


### PR DESCRIPTION
In powerman implementation, it has very strict http content type
checking, which makes it difficult to communicate with other
JSONRPC2 implementation. Therefore, I just remove the http
content type checking.
